### PR TITLE
Authenticate tenants before triggering devise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,11 @@
 class User < ActiveRecord::Base
+  acts_as_universal_and_determines_account
+    
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  acts_as_universal_and_determines_account
   has_one :member, :dependent => :destroy
 
 end


### PR DESCRIPTION
That way an InvalidTenantAccess exception will be thrown BEFORE triggering devise callbacks so that e.g. no invitation mails will be sent out by devise by mistake.
(Otherwise devise sends a 'broken' inviation mail for confirming the user account which then doesn't get created due to the exception and transaction rollback)